### PR TITLE
correcting _quarto file

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,7 +1,5 @@
 project:
   title: "template-computo-R"
-filters:
-  - pseudocode
 
    
 


### PR DESCRIPTION
It seems that the option that you put in the _quarto.yml file relative to the pseudocode compilation breaks the build. I removed it and it works locally with the computo-quarto extension. It will hopefully work remotely, which should allow you to make your submission.